### PR TITLE
Visitors implementation using EventBus and TreeTraverser

### DIFF
--- a/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/ParseTreeTraverser.java
+++ b/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/ParseTreeTraverser.java
@@ -1,0 +1,26 @@
+package com.github.chrisbrenton.grappa.parsetree.visitors;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+import com.google.common.collect.TreeTraverser;
+
+/**
+ * A {@link TreeTraverser} for {@link ParseNode} instances
+ *
+ * @see VisitOrder
+ */
+public final class ParseTreeTraverser
+    extends TreeTraverser<ParseNode>
+{
+    public static final TreeTraverser<ParseNode> INSTANCE
+        = new ParseTreeTraverser();
+
+    private ParseTreeTraverser()
+    {
+    }
+
+    @Override
+    public Iterable<ParseNode> children(final ParseNode root)
+    {
+        return root.getChildren();
+    }
+}

--- a/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/VisitOrder.java
+++ b/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/VisitOrder.java
@@ -1,0 +1,47 @@
+package com.github.chrisbrenton.grappa.parsetree.visitors;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+import com.google.common.base.Function;
+import com.google.common.collect.TreeTraverser;
+
+/**
+ * Determine which order we want to use when traversing a parse tree
+ *
+ * @see TreeTraverser
+ */
+public enum VisitOrder
+{
+    /**
+     * Preorder traversal
+     *
+     * @see TreeTraverser#preOrderTraversal(Object)
+     */
+    PREORDER(ParseTreeTraverser.INSTANCE::preOrderTraversal),
+
+    /**
+     * Postorder traversal
+     *
+     * @see TreeTraverser#postOrderTraversal(Object)
+     */
+    POSTORDER(ParseTreeTraverser.INSTANCE::postOrderTraversal),
+
+    /**
+     * Breadth first traversal
+     *
+     * @see TreeTraverser#breadthFirstTraversal(Object)
+     */
+    BREADTHFIRST(ParseTreeTraverser.INSTANCE::breadthFirstTraversal),
+    ;
+
+    private final Function<ParseNode, Iterable<ParseNode>> traverser;
+
+    VisitOrder(final Function<ParseNode, Iterable<ParseNode>> traverser)
+    {
+        this.traverser = traverser;
+    }
+
+    public Iterable<ParseNode> visit(final ParseNode node)
+    {
+        return traverser.apply(node);
+    }
+}

--- a/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/Visitor.java
+++ b/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/Visitor.java
@@ -1,0 +1,49 @@
+package com.github.chrisbrenton.grappa.parsetree.visitors;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+
+/**
+ * Marker interface for visitor instances
+ *
+ * <p>All visitor classes should implement this interface.</p>
+ *
+ * <p>Methods to visit a given type of node must obey the following conditions:
+ * </p>
+ *
+ * <ul>
+ *     <li>they must be {@code public};</li>
+ *     <li>they must have one argument, whose class is a subclass of {@link
+ *     ParseNode};</li>
+ *     <li>they should return {@code void}.</li>
+ * </ul>
+ *
+ * <p>For instance:</p>
+ *
+ * <pre>
+ *     public final class MyVisitor
+ *         implements Visitor
+ *     {
+ *         &#64;Subscribe
+ *         public void visitParentNode(final ParentNode node)
+ *         {
+ *             // code
+ *         }
+ *
+ *         &#64;Subscribe
+ *         public void visitChildNode(final ChildNode node)
+ *         {
+ *             // code
+ *         }
+ *
+ *         // etc
+ *     }
+ * </pre>
+ *
+ * <p><strong>Important note:</strong> if your nodes subclass each other, be
+ * aware that all {@code &#64;Subscribe} methods whose argument is either of the
+ * exact class <em>or any superclass</em> of that node will be called. Depending
+ * on the situation, this may be either desirable or undesirable.</p>
+ */
+public interface Visitor
+{
+}

--- a/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/VisitorRunner.java
+++ b/src/main/java/com/github/chrisbrenton/grappa/parsetree/visitors/VisitorRunner.java
@@ -1,0 +1,81 @@
+package com.github.chrisbrenton.grappa.parsetree.visitors;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+import com.google.common.eventbus.EventBus;
+
+import java.util.Objects;
+
+/**
+ * Run one or more visitor(s) on a given parse tree
+ *
+ * <p>The scenario to visit a parse tree is as follows:</p>
+ *
+ * <ul>
+ *     <li>create an instance of this class;</li>
+ *     <li>register one or more {@link Visitor}s;</li>
+ *     <li>call one of the run methods.</li>
+ * </ul>
+ *
+ * <p>The order in which the nodes of a parse tree are visited depend on the
+ * {@link VisitOrder visit order} that you define. By default, this will be a
+ * {@link VisitOrder#POSTORDER postorder} traversal.</p>
+ *
+ * <h2>Implementation details</h2>
+ *
+ * <p>When you {@code run()} the visitors, you determine an order to traverse
+ * the node; the order is an instance of {@link VisitOrder} which, given the
+ * root node, will generate an {@code Iterable} over all the nodes using its
+ * {@link VisitOrder#visit(ParseNode) visit()} method.</p>
+ *
+ * <p>The nodes are then fed to an {@link EventBus}, to which the visitors you
+ * will have registered in the runner will subscribe to. When a node is posted
+ * on the bus (see {@link EventBus#post(Object)}), the appropriate methods will
+ * be invoked with this node as an argument.</p>
+ *
+ * @see Visitor
+ * @see VisitOrder
+ */
+public final class VisitorRunner
+{
+    private final ParseNode node;
+    private final EventBus bus = new EventBus();
+
+    /**
+     * Constructor
+     *
+     * @param node the node at the root of the parse tree
+     */
+    public VisitorRunner(final ParseNode node)
+    {
+        this.node = Objects.requireNonNull(node);
+    }
+
+    /**
+     * Add one visitor to this runner
+     *
+     * @param visitor the visitor
+     */
+    public void addVisitor(final Visitor visitor)
+    {
+        bus.register(Objects.requireNonNull(visitor));
+    }
+
+    /**
+     * Visit all nodes of the parse tree in a given visit order
+     *
+     * @param visitOrder the order
+     */
+    public void run(final VisitOrder visitOrder)
+    {
+        Objects.requireNonNull(visitOrder).visit(node).forEach(bus::post);
+    }
+
+    /**
+     * Visit all nodes of the parse tree using a {@link VisitOrder#POSTORDER
+     * postorder traversal}
+     */
+    public void run()
+    {
+        run(VisitOrder.POSTORDER);
+    }
+}

--- a/src/test/java/com/github/cbrenton/grappa/parsetree/visit/ChildNode.java
+++ b/src/test/java/com/github/cbrenton/grappa/parsetree/visit/ChildNode.java
@@ -1,0 +1,12 @@
+package com.github.cbrenton.grappa.parsetree.visit;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+
+public final class ChildNode
+    extends ParseNode
+{
+    public ChildNode(final String value)
+    {
+        super(value);
+    }
+}

--- a/src/test/java/com/github/cbrenton/grappa/parsetree/visit/DummyParser.java
+++ b/src/test/java/com/github/cbrenton/grappa/parsetree/visit/DummyParser.java
@@ -1,0 +1,21 @@
+package com.github.cbrenton.grappa.parsetree.visit;
+
+import com.github.chrisbrenton.grappa.parsetree.annotations.GenerateNode;
+import com.github.fge.grappa.parsers.BaseParser;
+import com.github.fge.grappa.rules.Rule;
+
+public class DummyParser
+    extends BaseParser<Void>
+{
+    @GenerateNode(ParentNode.class)
+    public Rule parent()
+    {
+        return sequence(child(), child());
+    }
+
+    @GenerateNode(ChildNode.class)
+    public Rule child()
+    {
+        return EMPTY;
+    }
+}

--- a/src/test/java/com/github/cbrenton/grappa/parsetree/visit/DummyVisitor.java
+++ b/src/test/java/com/github/cbrenton/grappa/parsetree/visit/DummyVisitor.java
@@ -1,0 +1,18 @@
+package com.github.cbrenton.grappa.parsetree.visit;
+
+import com.github.chrisbrenton.grappa.parsetree.visitors.Visitor;
+import com.google.common.eventbus.Subscribe;
+
+public class DummyVisitor
+    implements Visitor
+{
+    @Subscribe
+    public void visit(final ParentNode node)
+    {
+    }
+
+    @Subscribe
+    public void visit(final ChildNode node)
+    {
+    }
+}

--- a/src/test/java/com/github/cbrenton/grappa/parsetree/visit/ParentNode.java
+++ b/src/test/java/com/github/cbrenton/grappa/parsetree/visit/ParentNode.java
@@ -1,0 +1,12 @@
+package com.github.cbrenton.grappa.parsetree.visit;
+
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+
+public final class ParentNode
+    extends ParseNode
+{
+    public ParentNode(final String value)
+    {
+        super(value);
+    }
+}

--- a/src/test/java/com/github/cbrenton/grappa/parsetree/visit/VisitorTest.java
+++ b/src/test/java/com/github/cbrenton/grappa/parsetree/visit/VisitorTest.java
@@ -1,0 +1,67 @@
+package com.github.cbrenton.grappa.parsetree.visit;
+
+import com.github.chrisbrenton.grappa.parsetree.listeners.ParseNodeConstructorRepository;
+import com.github.chrisbrenton.grappa.parsetree.listeners.ParseTreeListener;
+import com.github.chrisbrenton.grappa.parsetree.nodes.ParseNode;
+import com.github.chrisbrenton.grappa.parsetree.visitors.VisitorRunner;
+import com.github.fge.grappa.Grappa;
+import com.github.fge.grappa.run.ListeningParseRunner;
+import com.github.fge.grappa.run.ParsingResult;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
+public final class VisitorTest
+{
+    private DummyParser parser;
+    private ParseTreeListener<Void> listener;
+
+    @BeforeMethod
+    public void init()
+    {
+        final Class<DummyParser> parserClass = DummyParser.class;
+        final ParseNodeConstructorRepository repository
+            = new ParseNodeConstructorRepository(parserClass);
+
+        parser = Grappa.createParser(parserClass);
+        listener = new ParseTreeListener<>(repository);
+    }
+
+    @Test
+    public void visitOrderTest()
+    {
+        final ListeningParseRunner<Void> runner
+            = new ListeningParseRunner<>(parser.parent());
+
+        runner.registerListener(listener);
+
+        final ParsingResult<Void> result = runner.run("");
+
+        assertThat(result.isSuccess()).isTrue();
+
+        final ParseNode node = listener.getRootNode();
+
+        assertThat(node).isInstanceOf(ParentNode.class);
+
+        for (final ParseNode child: node.getChildren())
+            assertThat(child).isInstanceOf(ChildNode.class);
+
+        final DummyVisitor visitor = spy(new DummyVisitor());
+
+        final VisitorRunner visitorRunner = new VisitorRunner(node);
+        visitorRunner.addVisitor(visitor);
+
+        visitorRunner.run();
+
+        final InOrder inOrder = Mockito.inOrder(visitor);
+        inOrder.verify(visitor, times(2)).visit(any(ChildNode.class));
+        inOrder.verify(visitor).visit(any(ParentNode.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+}


### PR DESCRIPTION
The provided mechanism uses TreeTraverser to let the user choose the parse node traversal strategy, and EventBus to call the visitors of individual nodes.

This means, among other things, that ParseNode needs not have an accept() method anymore and that AbstractVisitor is not needed either.
